### PR TITLE
Make sure list is not empty (fixes #29)

### DIFF
--- a/CybORG/Agents/Wrappers/RedTableWrapper.py
+++ b/CybORG/Agents/Wrappers/RedTableWrapper.py
@@ -128,7 +128,9 @@ class RedTableWrapper(BaseWrapper):
 
     def _process_priv_esc(self, obs, hostname):
         if obs['success'] == False:
-            [info for info in self.red_info.values() if info[2] == hostname][0][4] = 'None'
+            red_info = [info for info in self.red_info.values() if info[2] == hostname]
+            if len(red_info) > 0:
+                red_info[0][4] = 'None'
         else:
             for hostid in obs:
                 if hostid == 'success':


### PR DESCRIPTION
This commit fixes #29 by checking the list size before writing `'None'` into the `'Access'` field.