### PR TITLE
Fixed setup.py to include version package data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,167 @@
-*.*~
+# Byte-compiled / optimized / DLL files
 __pycache__/
-*.pkl
-data/
-**/*.egg-info
-.python-version
-../../PycharmProjects/CybORG/.idea/
-.vscode/
-.DS_Store
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
 .pytest_cache/
-profiles/
-venv/*
-venv
-.idea/
-CybORG\.egg-info/
+cover/
 
-_pycache_/
-*.pyc
+# Translations
+*.mo
+*.pot
 
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# CybORG
 CybORG/Logs/
 CybORG/Emulator/Logs/
 CybORG/Emulator/logs/
@@ -30,5 +175,3 @@ CybORG/Emulator/AWS/Config/awsconfig.ini
 
 *.swp
 *.pstats
-
-.ipynb_checkpoints/

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
 import sys
+
 from setuptools import setup
 
-assert sys.version_info.major == 3 and sys.version_info.minor >= 7, \
-    "The CybORG repo is designed to work with Python 3.7 and greater." \
+assert sys.version_info.major == 3 and sys.version_info.minor >= 7, (
+    "The CybORG repo is designed to work with Python 3.7 and greater."
     + "Please install it before proceeding."
+)
 
-with open('Requirements.txt') as f:
+with open("Requirements.txt") as f:
     requirements = f.read().splitlines()
 
-with open('CybORG/version.txt') as f:
+with open("CybORG/version.txt") as f:
     CYBORG_VERSION = f.read()[:-1]
 
 
@@ -17,4 +19,6 @@ setup(
     version=CYBORG_VERSION,
     install_requires=requirements,
     description="A Cyber Security Research Environment",
+    include_package_data=True,
+    package_data={"CybORG": ["*.txt"]},
 )


### PR DESCRIPTION
Changes:

* Updated `.gitignore` since there are python-related files it wasn't accounting for
* Minor formatting changes in `setup.py` due to VSCode auto-formatting extensions
* **Most important:** added `*.txt` files as package data so that `version.txt` is copied to package location upon installation [here](https://github.com/cage-challenge/CybORG/pull/44/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R22-R23)